### PR TITLE
Remove "dropped frames" metric

### DIFF
--- a/perfsuite/src/main/java/com/booking/perfsuite/rendering/RenderingMetrics.kt
+++ b/perfsuite/src/main/java/com/booking/perfsuite/rendering/RenderingMetrics.kt
@@ -22,17 +22,6 @@ public data class RenderingMetrics(
     val frozenFrames: Long,
 
     /**
-     * Amount of "good" frames that potentially could be rendered, but were "dropped" due to
-     * rendering performance issues.
-     *
-     * For instance if we target 60fps, the "good" frame would be any frame rendered for less than
-     * 16ms. But when we see "slow" frame that take 48ms to render, it spend the same time to render
-     * as 3 "good" frames would spend. That means that due to performance issue the app has rendered
-     * 1 frame, but 2 potentially good frames were dropped
-     */
-    val droppedFrames: Long,
-
-    /**
      * Total time of freezing the UI due to rendering of the slow frames per screen session.
      * This metric accumulates all freeze durations during the screen session
      */
@@ -44,4 +33,3 @@ public data class RenderingMetrics(
      */
     val foregroundTimeMs: Long? = null
 )
-

--- a/perfsuite/src/main/java/com/booking/perfsuite/rendering/RenderingMetricsMapper.kt
+++ b/perfsuite/src/main/java/com/booking/perfsuite/rendering/RenderingMetricsMapper.kt
@@ -22,7 +22,6 @@ public object RenderingMetricsMapper {
         var total = 0L
         var slow = 0L
         var frozen = 0L
-        var dropped = 0L
         var totalFreezeTime = 0L
 
         totalMetrics.forEach { frameDuration, numberOfFrames ->
@@ -36,15 +35,12 @@ public object RenderingMetricsMapper {
                 totalFreezeTime += frameDuration * numberOfFrames
             }
             total += numberOfFrames.toLong()
-
-            dropped += (frameDuration / SLOW_FRAME_THRESHOLD_MS) * numberOfFrames
         }
 
         return RenderingMetrics(
             totalFrames = total,
             slowFrames = slow,
             frozenFrames = frozen,
-            droppedFrames = dropped,
             totalFreezeTimeMs = totalFreezeTime,
             foregroundTimeMs = foregroundTime
         )


### PR DESCRIPTION
Remove legacy experimental metric which was proven to be too confusing and useless most of the time. In the end it was effectively replaced with `totalFreezeTimeMs`