### PR TITLE
Fix Memory Leak in NextDrawListener by Properly Removing the Draw Listener

### DIFF
--- a/perfsuite/src/main/java/com/booking/perfsuite/internal/FrameDrawUtil.kt
+++ b/perfsuite/src/main/java/com/booking/perfsuite/internal/FrameDrawUtil.kt
@@ -37,10 +37,11 @@ public fun View.doOnNextDraw(action: () -> Unit) {
 
     doOnAttach { view ->
         view.viewTreeObserver.addOnDrawListener(nextDrawListener)
-    }
-
-    doOnDetach { view ->
-        view.viewTreeObserver.takeIf { it.isAlive }?.removeOnDrawListener(nextDrawListener)
+        doOnDetach { detachedView ->
+            detachedView.viewTreeObserver
+                .takeIf { it.isAlive }
+                ?.removeOnDrawListener(nextDrawListener)
+        }
     }
 }
 

--- a/perfsuite/src/main/java/com/booking/perfsuite/internal/FrameDrawUtil.kt
+++ b/perfsuite/src/main/java/com/booking/perfsuite/internal/FrameDrawUtil.kt
@@ -6,6 +6,7 @@ import android.view.ViewTreeObserver
 import android.view.Window
 import androidx.annotation.UiThread
 import androidx.core.view.doOnAttach
+import java.lang.ref.WeakReference
 
 /**
  * Performs the given action when the activity very first frame is drawn.
@@ -72,12 +73,12 @@ private fun Window.callbackWrapper(): WindowCallbackWrapper {
 }
 
 private class NextDrawListener(
-    val view: View,
+    view: View,
     val callback: () -> Unit
 ) : ViewTreeObserver.OnDrawListener {
 
     private var isInvoked = false
-    private var viewTreeObserver = view.viewTreeObserver
+    private val viewRef = WeakReference(view)
 
     override fun onDraw() {
         if (isInvoked) return
@@ -85,10 +86,8 @@ private class NextDrawListener(
 
         callback()
 
-        view.post {
-            if (viewTreeObserver.isAlive) {
-                viewTreeObserver.removeOnDrawListener(this)
-            }
+        viewRef.get()?.post {
+            viewRef.get()?.viewTreeObserver?.takeIf { it.isAlive }?.removeOnDrawListener(this)
         }
     }
 }

--- a/perfsuite/src/main/java/com/booking/perfsuite/internal/FrameDrawUtil.kt
+++ b/perfsuite/src/main/java/com/booking/perfsuite/internal/FrameDrawUtil.kt
@@ -6,6 +6,7 @@ import android.view.ViewTreeObserver
 import android.view.Window
 import androidx.annotation.UiThread
 import androidx.core.view.doOnAttach
+import androidx.core.view.doOnDetach
 import java.lang.ref.WeakReference
 
 /**
@@ -31,10 +32,15 @@ public fun Activity.doOnFirstDraw(action: () -> Unit) {
 @UiThread
 public fun View.doOnNextDraw(action: () -> Unit) {
     if (!viewTreeObserver.isAlive) return
-    doOnAttach {
-        viewTreeObserver.addOnDrawListener(
-            NextDrawListener(this, action)
-        )
+
+    val nextDrawListener = NextDrawListener(this, action)
+
+    doOnAttach { view ->
+        view.viewTreeObserver.addOnDrawListener(nextDrawListener)
+    }
+
+    doOnDetach { view ->
+        view.viewTreeObserver.takeIf { it.isAlive }?.removeOnDrawListener(nextDrawListener)
     }
 }
 


### PR DESCRIPTION
# Fix Memory Leak in NextDrawListener by Properly Removing the Draw Listener

## Description

This pull request addresses a memory leak reported by LeakCanary where the `NextDrawListener` was holding a strong reference to a `View` through its cached `viewTreeObserver`. This prevented the listener from being removed properly when the view was detached, leading to the following leak chain:

```Non-fatal Exception:
InputMethodManager.mCurRootView is leaking.
androidx.swiperefreshlayout.widget.SwipeRefreshLayout.ObjectWatcher was watching this because Fragment received Fragment#onDestroyView() callback (references to its views should be cleared to prevent leaks) (MemoryLeak: 7ebbad90c9850354c61b21b1c37ccf2455b65707)
com.booking.perfsuite.internal.NextDrawListener.view (NextDrawListener.kt)
java.util.ArrayList.[1] (ArrayList.kt)
android.view.ViewTreeObserver.mOnDrawListeners (ViewTreeObserver.kt)
android.view.View$AttachInfo.mTreeObserver (View$AttachInfo.kt)
android.view.ViewRootImpl.mAttachInfo (ViewRootImpl.kt)
android.view.inputmethod.InputMethodManager.mCurRootView (InputMethodManager.kt)
android.view.inputmethod.InputMethodManager.sInstance (InputMethodManager.kt) 
```

## Root Cause

-  The `NextDrawListener` was storing a strong reference to the view, which kept the view (and its associated resources) in memory longer than necessary.

- The listener cached the `viewTreeObserver` at construction time. When the view was detached, a new `ViewTreeObserver` could be created, making the cached observer no longer valid. As a result, the listener was not removed, causing the leak.

## Changes Made

1. **Lifecycle-Aware Listener Management:**  
   - The listener is now added on view attachment using a `doOnAttach` extension.
   - The listener is removed on view detachment using a `doOnDetach` extension. This ensures that when the view is no longer in use, the listener is properly cleaned up.

2. **Updated Removal Logic:**  
   - Instead of relying on the cached `viewTreeObserver`, the removal now uses the current `viewTreeObserver` to ensure that the listener is correctly removed even if the view’s observer has changed due to lifecycle events.

## Benefits

- **Prevents Memory Leaks:**  
  By ensuring the listener is removed when the view detaches, the view and its associated resources are no longer held in memory by the listener.

- **Cleaner Lifecycle Management:**  
  This approach aligns the listener's lifecycle with the view’s lifecycle, reducing the risk of leaks and improving overall resource management.